### PR TITLE
Two textures render onto the rectangle target simultaneously

### DIFF
--- a/LearnOpenGL/main.cpp
+++ b/LearnOpenGL/main.cpp
@@ -44,61 +44,93 @@ int main()
 
 	// Build and compile shader program
 	Shader myShader("shader.vert", "shader.frag");
-	
-	// Setup texture
-	unsigned int texture;
-	glGenTextures(1, &texture);
-	glBindTexture(GL_TEXTURE_2D, texture);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-	
-	int imageWidth, imageHeight, numChannels;
-	unsigned char* imageData = stbi_load("stone_texture.jpeg", &imageWidth, &imageHeight, &numChannels, 0);
-	if (imageData)
-	{
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, imageWidth, imageHeight, 0, GL_RGB, GL_UNSIGNED_BYTE, imageData);
-		glGenerateMipmap(GL_TEXTURE_2D);
-	}
-	else
-	{
-		cout << "Failed to load texture" << endl;
-	}
-	stbi_image_free(imageData);
 
 	// Setup vertex data/buffers and configure vertex attributes
 	GLfloat vertices[] = {
-		// positions			// colors				// texture coords	
-		0.71f,	0.71f,	0.0f,	0.86f, 0.82f, 0.71f,	1.0f, 1.0f, // top right
-		-0.71f, 0.71f,  0.0f,	0.82f, 0.68f, 0.51f,	0.0f, 1.0f, // top left
-		-0.71f,	-0.71f, 0.0f,	0.59f, 0.65f, 0.51f,	0.0f, 0.0f,	// bottom left
-		0.71f,	-0.71f, 0.0f,	0.42f, 0.58f, 0.57f,	1.0f, 0.0f, // bottom right
+		// positions			// colors					// texture coords	
+		0.71f,	0.71f,	0.0f,	219.0f, 209.0f, 180.0f,		1.0f, 1.0f, // top right
+		-0.71f, 0.71f,  0.0f,	209.0f, 173.0f, 130.0f,		0.0f, 1.0f, // top left
+		-0.71f,	-0.71f, 0.0f,	152.0f, 166.0f, 129.0f,		0.0f, 0.0f,	// bottom left
+		0.71f,	-0.71f, 0.0f,	106.0f, 148.0f, 144.0f,		1.0f, 0.0f, // bottom right
 	};
 	unsigned int indices[] = {
 		0, 1, 3,
 		1, 2, 3
 	};
 
+	// Setup buffers and array attributes
 	GLuint VAO, VBO, EBO;
-	glGenVertexArrays(1, &VAO);
-	glGenBuffers(1, &VBO);
-	glGenBuffers(1, &EBO);
 
+	glGenVertexArrays(1, &VAO);
 	glBindVertexArray(VAO);
+	
+	glGenBuffers(1, &VBO);
 	glBindBuffer(GL_ARRAY_BUFFER, VBO);
 	glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
+	
+	glGenBuffers(1, &EBO);
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, EBO);
 	glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indices), indices, GL_STATIC_DRAW);
 
 	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 8 * sizeof(GLfloat), (void*)0);
 	glEnableVertexAttribArray(0);
+	
 	glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 8 * sizeof(GLfloat), (void*)(3 * sizeof(GLfloat)));
 	glEnableVertexAttribArray(1);
+	
 	glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, 8 * sizeof(GLfloat), (void*)(6 * sizeof(GLfloat)));
 	glEnableVertexAttribArray(2);
 
-	//glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+	// Setup textures
+	unsigned int texture0, texture1;
+	
+	// First texture
+	glGenTextures(1, &texture0);
+	glBindTexture(GL_TEXTURE_2D, texture0);
+	
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+	
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+
+	// put vertical filp here
+
+	int imageWidth, imageHeight, numChannels;
+	unsigned char* imageData = stbi_load("container.jpg", &imageWidth, &imageHeight, &numChannels, 0);
+	if (!imageData)
+	{
+		cout << "Failed to load container texture" << endl;
+		return -1;
+	}
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, imageWidth, imageHeight, 0, GL_RGB, GL_UNSIGNED_BYTE, imageData);
+	glGenerateMipmap(GL_TEXTURE_2D);
+	stbi_image_free(imageData);
+
+	// Second texture
+	glGenTextures(1, &texture1);
+	glBindTexture(GL_TEXTURE_2D, texture1);
+
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+
+	imageData = stbi_load("awesomeface.png", &imageWidth, &imageHeight, &numChannels, 0);
+	if (!imageData)
+	{
+		cout << "Failed to load awesomeface texture" << endl;
+	}
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, imageWidth, imageHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, imageData);
+	glGenerateMipmap(GL_TEXTURE_2D);
+	stbi_image_free(imageData);
+
+	// Tell OpenGL which texture unit each shader sampler belongs to
+	myShader.use();
+	myShader.setInt("texture0", 0);
+	myShader.setInt("texture1", 1);
+
 	while (!glfwWindowShouldClose(window))
 	{
 		processInput(window);
@@ -107,7 +139,13 @@ int main()
 		glClear(GL_COLOR_BUFFER_BIT);
 
 		myShader.use();
+		
+		glActiveTexture(GL_TEXTURE0);
+		glBindTexture(GL_TEXTURE_2D, texture0);
 
+		glActiveTexture(GL_TEXTURE1);
+		glBindTexture(GL_TEXTURE_2D, texture1);
+		
 		glBindVertexArray(VAO);
 		glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0);
 

--- a/LearnOpenGL/shader.frag
+++ b/LearnOpenGL/shader.frag
@@ -3,8 +3,12 @@
 out vec4 FragColor;
 
 in vec3 customColor;
+in vec2 TexCoord;
+
+uniform sampler2D texture0;
+uniform sampler2D texture1;
 
 void main()
 {
-	FragColor = vec4(customColor, 1.0);
+	FragColor = mix(texture(texture0, TexCoord), texture(texture1, TexCoord), 0.2);
 }

--- a/LearnOpenGL/shader.vert
+++ b/LearnOpenGL/shader.vert
@@ -10,6 +10,6 @@ out vec2 TexCoord;
 void main()
 {
 	gl_Position = vec4(aPos, 1.0);
-	customColor = aColor;
+	customColor = normalize(aColor);
 	TexCoord = aTexCoord;
 }


### PR DESCRIPTION
The fragment shader uses the built-in mix function to linearly interpolate pixel color between the two provided textures